### PR TITLE
fpnew_divsqrt_th_64_multi: NaN-box narrower FP operands instead of zero-extending

### DIFF
--- a/src/fpnew_divsqrt_th_64_multi.sv
+++ b/src/fpnew_divsqrt_th_64_multi.sv
@@ -350,8 +350,8 @@ module fpnew_divsqrt_th_64_multi #(
     .dp_vfdsu_ex1_pipex_iid         ( '0                        ), // Don't care, used in C910
     .dp_vfdsu_ex1_pipex_imm0        ( 3'b111                    ), // Round mode, set to 3'b111 to select vfpu_yy_xx_rm signal
     .dp_vfdsu_ex1_pipex_sel         ( op_sel                    ), // 3. Select operands, start operation
-    .dp_vfdsu_ex1_pipex_srcf0       ( {{(64-WIDTH){1'b0}}, srcf0_q} ), // Input for operand 0
-    .dp_vfdsu_ex1_pipex_srcf1       ( {{(64-WIDTH){1'b0}}, srcf1_q} ), // Input for operand 1
+    .dp_vfdsu_ex1_pipex_srcf0       ( {{(64-WIDTH){1'b1}}, srcf0_q} ), // Input for operand 0
+    .dp_vfdsu_ex1_pipex_srcf1       ( {{(64-WIDTH){1'b1}}, srcf1_q} ), // Input for operand 1
     .dp_vfdsu_fdiv_gateclk_issue    ( 1'b1                      ), // Local clock enable (same as above)
     .dp_vfdsu_idu_fdiv_issue        ( op_starting               ), // 1. Issue fdiv (FSM in ctrl)
     .forever_cpuclk                 ( clk_i                     ), // Clock input


### PR DESCRIPTION
## Description

This PR fixes https://github.com/openhwgroup/cvfpu/issues/184.

In the `RV32F_Xsflt` configuration with `DivSqrtSel=THMULTI`, FP32 division incorrectly returns canonical NaN (`0x7fc00000`). This is caused by explicit zero-extending 32-bit FP operands to 64 bits before passing them to `i_ct_vfdsu_top`.

Per the RISC-V Unprivileged ISA specification (Section 22.2, "NaN-boxing of Narrower Values"), narrower FP values must be 1-extended (NaN-boxed) when placed in a wider datapath.

## Changes

`fpnew_divsqrt_th_64_multi.sv`: replaced `{(64-WIDTH){1'b0}}` with `{(64-WIDTH){1'b1}}` for `dp_vfdsu_ex1_pipex_srcf0` and `dp_vfdsu_ex1_pipex_srcf1`.